### PR TITLE
Add GitOps manifests for Argo CD test and prod environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,118 +1,120 @@
-# Instructions
+# GitOps манифесты для инструкций
 
-Полноценный пример приложения для публикации и редактирования инструкций.
-Бэкенд реализован на Spring Boot, данные хранятся в PostgreSQL. Фронтенд
-создан на React + TypeScript и использует богатый текстовый редактор
-(react-quill), позволяющий форматировать статьи перед сохранением.
+Репозиторий содержит Kubernetes-манифесты для развёртывания приложения "Instructions"
+в двух окружениях (`test` и `prod`) через Argo CD. В каждом окружении поднимаются три
+компонента:
 
-## Состав проекта
+- PostgreSQL из Helm-чарта Bitnami;
+- backend (Spring Boot API);
+- frontend (React SPA).
 
-- `backend` — REST API на Spring Boot 3 (Java 17, Spring Data JPA, Bean Validation).
-- `frontend` — одностраничное приложение на Vite + React + TypeScript.
-- `docker-compose.yml` — инфраструктура из PostgreSQL, бэкенда и собранного фронтенда.
+## Структура репозитория
 
-## Запуск локально
+```
+clusters/
+  test/        # корневой Application (app-of-apps) и дочерние Applications для test
+  prod/        # корневой Application (app-of-apps) и дочерние Applications для prod
+apps/
+  backend/     # base + overlays для backend
+  frontend/    # base + overlays для frontend
+  db/          # overlays с секретами и Argo CD Applications на PostgreSQL
+infra/argocd/  # дополнительные объекты Argo CD (проекты и т.п.)
+```
 
-### Backend
+### Backend / Frontend
+
+Базовые директории (`apps/<component>/base`) содержат Deployment, Service и Ingress с
+минимальными параметрами. В `overlays/test` и `overlays/prod` задаются namespace,
+количество реплик и ingress-хосты. Сами образы меняются через секцию `images` в
+`kustomization.yaml`.
+
+- Backend слушает порт `8080`, использует секрет `db-auth` и переменные `DB_*` для
+  подключения к БД. В обоих окружениях развёрнута 1 реплика.
+- Frontend слушает порт `80`, имеет `readinessProbe` на `/`. В `test` — 1 реплика,
+  в `prod` — 2 реплики.
+
+### База данных
+
+В директории `apps/db/overlays/<env>` лежит секрет `db-auth` и Argo CD Application,
+который разворачивает Bitnami PostgreSQL (release `postgres`) с переопределением имени
+сервиса (`fullnameOverride: postgres`). Бэкенд подключается к сервису `postgres:5432`.
+
+## Настройка образов
+
+По умолчанию в overlays используются плейсхолдеры:
+
+- Backend: `ghcr.io/boldrqwe/backend:latest`
+- Frontend: `ghcr.io/boldrqwe/frontend:latest`
+
+Чтобы заменить образы, отредактируйте `images` в файлах:
+
+- `apps/backend/overlays/test/kustomization.yaml`
+- `apps/backend/overlays/prod/kustomization.yaml`
+- `apps/frontend/overlays/test/kustomization.yaml`
+- `apps/frontend/overlays/prod/kustomization.yaml`
+
+Например:
+
+```yaml
+images:
+  - name: backend
+    newName: ghcr.io/boldrqwe/backend
+    newTag: v1.2.3
+```
+
+## Настройка секретов БД
+
+Секрет `db-auth` содержит три ключа: `postgres-password`, `password` (для пользователя
+`app`) и `replication-password`. Значения должны быть в Base64. Для генерации можно
+воспользоваться `printf 'MyPassword' | base64`.
+
+Обновите файлы:
+
+- `apps/db/overlays/test/secret-db-auth.yaml`
+- `apps/db/overlays/prod/secret-db-auth.yaml`
+
+и замените плейсхолдеры на свои значения. Пароли в обоих окружениях могут отличаться.
+
+## Персистентность БД
+
+По умолчанию `primary.persistence.enabled=false`, чтобы можно было быстро стартовать без
+PVC. Для включения постоянного хранения в `prod` (или другом окружении) измените блок
+`primary.persistence` в `apps/db/overlays/prod/app-postgres.yaml`, например:
+
+```yaml
+primary:
+  persistence:
+    enabled: true
+    storageClass: <storage-class>
+    size: 10Gi
+```
+
+## Развёртывание через Argo CD
+
+1. В Argo CD UI создайте приложение `env-test`:
+   - Repo URL: `https://github.com/boldrqwe/k8s.git`
+   - Path: `clusters/test`
+   - Destination: выбранный кластер, namespace `argocd`
+   - Включите автоматическую синхронизацию (prune, self-heal) и опцию `Create Namespace`.
+2. Аналогично создайте приложение `env-prod`, указав Path `clusters/prod`.
+
+Корневые приложения синхронизируют дочерние Applications (`db`, `backend`, `frontend`).
+После синхронизации сервисы будут доступны по хостам:
+
+- Test: `test.79.174.84.176.sslip.io` (frontend), `api-test.79.174.84.176.sslip.io` (backend)
+- Prod: `app.79.174.84.176.sslip.io` (frontend), `api.79.174.84.176.sslip.io` (backend)
+
+## Проверка манифестов
+
+Для локальной проверки соберите манифесты через Kustomize:
 
 ```bash
-cd backend
-mvn spring-boot:run
+kustomize build apps/backend/overlays/test
+kustomize build apps/backend/overlays/prod
+kustomize build apps/frontend/overlays/test
+kustomize build apps/frontend/overlays/prod
+kustomize build apps/db/overlays/test
+kustomize build apps/db/overlays/prod
 ```
 
-Доступные переменные окружения:
-
-- `DB_HOST` (по умолчанию `localhost`)
-- `DB_PORT` (по умолчанию `5432`)
-- `DB_NAME` (по умолчанию `instructions`)
-- `DB_USERNAME` (по умолчанию `postgres`)
-- `DB_PASSWORD` (по умолчанию `postgres`)
-- `CORS_ALLOWED_ORIGINS` (по умолчанию `http://localhost:5173`)
-
-При первом запуске создаются две демонстрационные статьи.
-REST API доступно по адресу `http://localhost:8080/api/articles`.
-
-### Frontend
-
-```bash
-cd frontend
-npm install
-npm run dev
-```
-
-По умолчанию фронтенд отправляет запросы на `http://localhost:8080`.
-Можно переопределить адрес API, задав переменную `VITE_API_BASE_URL`.
-
-## Docker Compose
-
-Для проверки полного стека выполните:
-
-```bash
-docker compose up --build
-```
-
-Сервисы и порты:
-
-- PostgreSQL: `localhost:5432`
-- Backend: `http://localhost:8080`
-- Frontend: `http://localhost:3000`
-
-При необходимости можно переопределить переменные окружения Compose:
-`POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `CORS_ALLOWED_ORIGINS`,
-`VITE_API_BASE_URL`.
-
-## Деплой на Railway / в Docker
-
-- Бэкенд имеет Dockerfile и запускается командой
-  `java $JAVA_OPTS -jar /app/app.jar`. Railway автоматически определит порт через переменную `PORT`.
-- Фронтенд собирается в статический бандл и отдаётся nginx. При сборке можно
-  переопределить `VITE_API_BASE_URL`, чтобы прописать URL REST API в бандл.
-- Для production-деплоя достаточно выполнить `docker build` для каждой части
-  или использовать `docker compose build`/`push`.
-
-## API
-
-| Метод | Маршрут                 | Описание                 |
-|-------|------------------------|--------------------------|
-| GET   | `/api/articles`        | Список всех статей       |
-| GET   | `/api/articles/{id}`   | Получение статьи по id   |
-| POST  | `/api/articles`        | Создание новой статьи    |
-| PUT   | `/api/articles/{id}`   | Обновление существующей  |
-| DELETE| `/api/articles/{id}`   | Удаление статьи          |
-
-Пример тела запроса:
-
-```json
-{
-  "title": "Как развернуть проект",
-  "content": "<p>Подробное описание с форматированием…</p>"
-}
-```
-
-Ошибки возвращаются в формате:
-
-```json
-{
-  "timestamp": "2024-03-19T12:00:00Z",
-  "status": 400,
-  "error": "Bad Request",
-  "message": "Данные заполнены некорректно",
-  "details": ["title: Заголовок обязателен"]
-}
-```
-
-## Тестирование
-
-- `mvn test` — интеграционные тесты REST API (используется H2 в режиме PostgreSQL).
-- `npm run lint` и `npm run build` — проверка фронтенда.
-
-## Структура фронтенда
-
-Интерфейс содержит панель со списком статей и редактор. Для текста доступно:
-заголовки, списки, выделение, цитаты, блоки кода, ссылки, изображения и видео.
-После сохранения статья обновляется в списке без перезагрузки страницы.
-
-## Скриншоты
-
-Фронтенд генерирует современный UI (см. директорию `frontend/src`). При необходимости
-можно подключить собственную тему или заменить редактор на другой.
+Все манифесты должны успешно генерироваться и соответствовать требованиям Kubernetes 1.24+.

--- a/apps/backend/base/deployment.yaml
+++ b/apps/backend/base/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: backend:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DB_HOST
+              value: postgres
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_NAME
+              value: app
+            - name: DB_USER
+              value: app
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-auth
+                  key: password
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/apps/backend/base/ingress.yaml
+++ b/apps/backend/base/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: backend
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: backend.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8080

--- a/apps/backend/base/kustomization.yaml
+++ b/apps/backend/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/backend/base/service.yaml
+++ b/apps/backend/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  type: ClusterIP
+  selector:
+    app: backend
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/apps/backend/overlays/prod/kustomization.yaml
+++ b/apps/backend/overlays/prod/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: prod
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - patch-deployment.yaml
+  - patch-ingress.yaml
+images:
+  - name: backend
+    newName: ghcr.io/boldrqwe/backend
+    newTag: latest

--- a/apps/backend/overlays/prod/patch-deployment.yaml
+++ b/apps/backend/overlays/prod/patch-deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 1

--- a/apps/backend/overlays/prod/patch-ingress.yaml
+++ b/apps/backend/overlays/prod/patch-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: backend
+spec:
+  rules:
+    - host: api.79.174.84.176.sslip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8080

--- a/apps/backend/overlays/test/kustomization.yaml
+++ b/apps/backend/overlays/test/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: test
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - patch-deployment.yaml
+  - patch-ingress.yaml
+images:
+  - name: backend
+    newName: ghcr.io/boldrqwe/backend
+    newTag: latest

--- a/apps/backend/overlays/test/patch-deployment.yaml
+++ b/apps/backend/overlays/test/patch-deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 1

--- a/apps/backend/overlays/test/patch-ingress.yaml
+++ b/apps/backend/overlays/test/patch-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: backend
+spec:
+  rules:
+    - host: api-test.79.174.84.176.sslip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8080

--- a/apps/db/overlays/prod/app-postgres.yaml
+++ b/apps/db/overlays/prod/app-postgres.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postgres-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.bitnami.com/bitnami
+    chart: postgresql
+    targetRevision: 15.5.20
+    helm:
+      releaseName: postgres
+      values: |
+        fullnameOverride: postgres
+        auth:
+          existingSecret: db-auth
+          username: app
+          database: app
+        primary:
+          persistence:
+            enabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/db/overlays/prod/kustomization.yaml
+++ b/apps/db/overlays/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: prod
+resources:
+  - secret-db-auth.yaml
+  - app-postgres.yaml

--- a/apps/db/overlays/prod/secret-db-auth.yaml
+++ b/apps/db/overlays/prod/secret-db-auth.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-auth
+  namespace: prod
+  labels:
+    app.kubernetes.io/name: db-auth
+    app.kubernetes.io/part-of: database
+type: Opaque
+data:
+  postgres-password: c2VjdXJlY2hhbmdl
+  password: c2VjdXJlY2hhbmdl
+  replication-password: c2VjdXJlY2hhbmdl

--- a/apps/db/overlays/test/app-postgres.yaml
+++ b/apps/db/overlays/test/app-postgres.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postgres-test
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.bitnami.com/bitnami
+    chart: postgresql
+    targetRevision: 15.5.20
+    helm:
+      releaseName: postgres
+      values: |
+        fullnameOverride: postgres
+        auth:
+          existingSecret: db-auth
+          username: app
+          database: app
+        primary:
+          persistence:
+            enabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/db/overlays/test/kustomization.yaml
+++ b/apps/db/overlays/test/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: test
+resources:
+  - secret-db-auth.yaml
+  - app-postgres.yaml

--- a/apps/db/overlays/test/secret-db-auth.yaml
+++ b/apps/db/overlays/test/secret-db-auth.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-auth
+  namespace: test
+  labels:
+    app.kubernetes.io/name: db-auth
+    app.kubernetes.io/part-of: database
+type: Opaque
+data:
+  postgres-password: Y2hhbmdlbWU=
+  password: Y2hhbmdlbWU=
+  replication-password: Y2hhbmdlbWU=

--- a/apps/frontend/base/deployment.yaml
+++ b/apps/frontend/base/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: frontend:latest
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/apps/frontend/base/ingress.yaml
+++ b/apps/frontend/base/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: frontend.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80

--- a/apps/frontend/base/kustomization.yaml
+++ b/apps/frontend/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/frontend/base/service.yaml
+++ b/apps/frontend/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/apps/frontend/overlays/prod/kustomization.yaml
+++ b/apps/frontend/overlays/prod/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: prod
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - patch-deployment.yaml
+  - patch-ingress.yaml
+images:
+  - name: frontend
+    newName: ghcr.io/boldrqwe/frontend
+    newTag: latest

--- a/apps/frontend/overlays/prod/patch-deployment.yaml
+++ b/apps/frontend/overlays/prod/patch-deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 2

--- a/apps/frontend/overlays/prod/patch-ingress.yaml
+++ b/apps/frontend/overlays/prod/patch-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+spec:
+  rules:
+    - host: app.79.174.84.176.sslip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80

--- a/apps/frontend/overlays/test/kustomization.yaml
+++ b/apps/frontend/overlays/test/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: test
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - patch-deployment.yaml
+  - patch-ingress.yaml
+images:
+  - name: frontend
+    newName: ghcr.io/boldrqwe/frontend
+    newTag: latest

--- a/apps/frontend/overlays/test/patch-deployment.yaml
+++ b/apps/frontend/overlays/test/patch-deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 1

--- a/apps/frontend/overlays/test/patch-ingress.yaml
+++ b/apps/frontend/overlays/test/patch-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+spec:
+  rules:
+    - host: test.79.174.84.176.sslip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80

--- a/clusters/prod/apps.yaml
+++ b/clusters/prod/apps.yaml
@@ -1,0 +1,85 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: env-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boldrqwe/k8s.git
+    targetRevision: HEAD
+    path: clusters/prod
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: db-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boldrqwe/k8s.git
+    targetRevision: HEAD
+    path: apps/db/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: backend-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boldrqwe/k8s.git
+    targetRevision: HEAD
+    path: apps/backend/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: frontend-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boldrqwe/k8s.git
+    targetRevision: HEAD
+    path: apps/frontend/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/clusters/test/apps.yaml
+++ b/clusters/test/apps.yaml
@@ -1,0 +1,85 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: env-test
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boldrqwe/k8s.git
+    targetRevision: HEAD
+    path: clusters/test
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: db-test
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boldrqwe/k8s.git
+    targetRevision: HEAD
+    path: apps/db/overlays/test
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: backend-test
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boldrqwe/k8s.git
+    targetRevision: HEAD
+    path: apps/backend/overlays/test
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: frontend-test
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boldrqwe/k8s.git
+    targetRevision: HEAD
+    path: apps/frontend/overlays/test
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infra/argocd/projects/default.yaml
+++ b/infra/argocd/projects/default.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: default
+  namespace: argocd
+spec:
+  description: Default project for environment applications
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: '*'
+      server: https://kubernetes.default.svc
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'


### PR DESCRIPTION
## Summary
- add Argo CD app-of-apps definitions for the test and prod clusters
- create backend and frontend kustomize bases and overlays with Traefik ingress routing
- configure PostgreSQL overlays with Argo CD Applications and document repo usage

## Testing
- not run (kustomize CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6f7a580a4832a854332e4fd6698bd