### PR TITLE
Add basic-authenticated login endpoint issuing JWT tokens

### DIFF
--- a/src/main/java/com/example/instructions/api/AuthController.java
+++ b/src/main/java/com/example/instructions/api/AuthController.java
@@ -1,0 +1,26 @@
+package com.example.instructions.api;
+
+import com.example.instructions.security.JwtTokenService;
+import com.example.instructions.security.JwtTokenService.TokenResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final JwtTokenService jwtTokenService;
+
+    public AuthController(JwtTokenService jwtTokenService) {
+        this.jwtTokenService = jwtTokenService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(Authentication authentication) {
+        TokenResponse response = jwtTokenService.generateToken(authentication);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/instructions/security/JwtProperties.java
+++ b/src/main/java/com/example/instructions/security/JwtProperties.java
@@ -1,0 +1,42 @@
+package com.example.instructions.security;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+@ConfigurationProperties("app.jwt")
+public class JwtProperties {
+
+    private static final Duration DEFAULT_ACCESS_TOKEN_TTL = Duration.ofHours(1);
+    private static final String DEFAULT_ISSUER = "instructions-api";
+
+    private String secret;
+    private Duration accessTokenTtl;
+    private String issuer;
+
+    public String getSecret() {
+        Assert.hasText(secret, "JWT secret must not be empty");
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public Duration getAccessTokenTtl() {
+        return accessTokenTtl != null ? accessTokenTtl : DEFAULT_ACCESS_TOKEN_TTL;
+    }
+
+    public void setAccessTokenTtl(Duration accessTokenTtl) {
+        this.accessTokenTtl = accessTokenTtl;
+    }
+
+    public String getIssuer() {
+        return StringUtils.hasText(issuer) ? issuer : DEFAULT_ISSUER;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+}

--- a/src/main/java/com/example/instructions/security/JwtTokenService.java
+++ b/src/main/java/com/example/instructions/security/JwtTokenService.java
@@ -1,0 +1,50 @@
+package com.example.instructions.security;
+
+import java.time.Instant;
+import java.util.List;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtTokenService {
+
+    private final JwtEncoder jwtEncoder;
+    private final JwtProperties jwtProperties;
+
+    public JwtTokenService(JwtEncoder jwtEncoder, JwtProperties jwtProperties) {
+        this.jwtEncoder = jwtEncoder;
+        this.jwtProperties = jwtProperties;
+    }
+
+    public TokenResponse generateToken(Authentication authentication) {
+        Instant issuedAt = Instant.now();
+        Instant expiresAt = issuedAt.plus(jwtProperties.getAccessTokenTtl());
+
+        List<String> roles = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .map(authority -> authority.startsWith("ROLE_") ? authority.substring(5) : authority)
+                .map(String::toUpperCase)
+                .distinct()
+                .toList();
+
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .issuer(jwtProperties.getIssuer())
+                .issuedAt(issuedAt)
+                .expiresAt(expiresAt)
+                .subject(authentication.getName())
+                .claim("roles", roles)
+                .build();
+
+        Jwt jwt = jwtEncoder.encode(JwtEncoderParameters.from(claims));
+
+        return new TokenResponse(jwt.getTokenValue(), "Bearer", expiresAt);
+    }
+
+    public record TokenResponse(String token, String tokenType, Instant expiresAt) {
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,13 +17,6 @@ spring:
     clean-disabled: false
     validate-on-migrate: false
     locations: classpath:db/migration
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          issuer-uri: http://localhost/realms/demo
-
-
 logging:
   level:
     root: INFO
@@ -32,5 +25,9 @@ app:
   admin:
     username: ${APP_ADMIN_USERNAME:admin}
     password: ${APP_ADMIN_PASSWORD:}
+  jwt:
+    secret: ${APP_JWT_SECRET:change-me-please-change-me-please}
+    issuer: ${APP_JWT_ISSUER:instructions-api}
+    access-token-ttl: ${APP_JWT_ACCESS_TOKEN_TTL:PT1H}
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}


### PR DESCRIPTION
## Summary
- add an /api/v1/auth/login endpoint secured with HTTP Basic that issues JWT access tokens
- configure JWT encoding/decoding with an application secret and update security configuration
- expose app.jwt configuration properties for token settings

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e2e6723fc8832ab1fe39029b31afe5