### PR TITLE
Handle missing authentication for basic login

### DIFF
--- a/src/main/java/com/example/instructions/api/AuthController.java
+++ b/src/main/java/com/example/instructions/api/AuthController.java
@@ -1,5 +1,6 @@
 package com.example.instructions.api;
 
+import com.example.instructions.common.ForbiddenException;
 import com.example.instructions.security.JwtTokenService;
 import com.example.instructions.security.JwtTokenService.TokenResponse;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,10 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<TokenResponse> login(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new ForbiddenException("Требуется базовая аутентификация");
+        }
+
         TokenResponse response = jwtTokenService.generateToken(authentication);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/instructions/security/JwtTokenService.java
+++ b/src/main/java/com/example/instructions/security/JwtTokenService.java
@@ -25,7 +25,9 @@ public class JwtTokenService {
         Instant issuedAt = Instant.now();
         Instant expiresAt = issuedAt.plus(jwtProperties.getAccessTokenTtl());
 
-        List<String> roles = authentication.getAuthorities().stream()
+        List<String> roles = authentication.getAuthorities() == null
+                ? List.of()
+                : authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .map(authority -> authority.startsWith("ROLE_") ? authority.substring(5) : authority)
                 .map(String::toUpperCase)


### PR DESCRIPTION
## Summary
- ensure the login endpoint validates that basic auth populated the security context before issuing a token
- guard JWT token generation against missing authorities collections when building the roles claim

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e2e96b87f4832a95d14b2338f11a80