### PR TITLE
Prevent manual persistence of tsvector columns

### DIFF
--- a/src/main/java/com/example/instructions/domain/Article.java
+++ b/src/main/java/com/example/instructions/domain/Article.java
@@ -60,7 +60,7 @@ public class Article {
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
 
-    @Column(name = "search_vector", columnDefinition = "tsvector")
+    @Column(name = "search_vector", columnDefinition = "tsvector", insertable = false, updatable = false)
     private String searchVector;
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/example/instructions/domain/Section.java
+++ b/src/main/java/com/example/instructions/domain/Section.java
@@ -38,7 +38,7 @@ public class Section {
     @Column(name = "markdown", nullable = false, columnDefinition = "text")
     private String markdown;
 
-    @Column(name = "search_vector", columnDefinition = "tsvector")
+    @Column(name = "search_vector", columnDefinition = "tsvector", insertable = false, updatable = false)
     private String searchVector;
 
     public UUID getId() {


### PR DESCRIPTION
## Summary
- mark Article.searchVector and Section.searchVector as database-managed fields
- avoid Hibernate attempting to insert varchar parameters into tsvector columns

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68e3910ee6d8832a828764d60ce66a31